### PR TITLE
Alec login redirect

### DIFF
--- a/src/ChatPrompt.jsx
+++ b/src/ChatPrompt.jsx
@@ -59,7 +59,7 @@ document.addEventListener('submit', function (event) {
 		body: jsonData
 	})
 	.then(response => {
-		// If the server returns a redirect, follow the redirect url. At this point, redirects only occur if the user
+		// If the server returns a redirect, follow the redirect url. At this point, a redirect only occurs if the user
 		// attempts to send a message but isn't logged in.  
 		if (response.redirected){
 			window.location.href = response.url;


### PR DESCRIPTION
The app successfully redirects to the login page if you try to send a message but aren't logged in. The next thing to do is to require the user to be authenticated in order to see any messages at all. I think that can be done just by requiring a CSRF token for GET requests in the same way that I already did for POST requests. 